### PR TITLE
ci/release: remove packages-dir

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,5 +28,3 @@ jobs:
 
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        packages-dir: systemdunitparser/dist


### PR DESCRIPTION
as deprecated by the action and unnecessary in this setup